### PR TITLE
prjconf: Add macro for rpm architecture for droidmedia build.

### DIFF
--- a/prjconf/macros.xml
+++ b/prjconf/macros.xml
@@ -1,0 +1,3 @@
+# device-specific macros:
+
+%device_rpm_architecture_string aarch64


### PR DESCRIPTION
[prjconf] Add macro for rpm architecture for droidmedia build. JB#52325